### PR TITLE
Update readme to fix typos

### DIFF
--- a/smartthings/README.md
+++ b/smartthings/README.md
@@ -7,9 +7,9 @@ Everything is configurable through UI. Available params:
 | Param          | Description              |
 |----------------|--------------------------|
 | broker_host    | MQTT broker host         |
-| broker_port    | MQQT broker port         |
+| broker_port    | MQTT broker port         |
 | login          | MQTT broker login        |
-| password       | MQTT broker passwor      |
+| password       | MQTT broker password     |
 | preface        | Preface for topics       |
 | state_suffix   | State topics suffix      |
 | command_suffix | Command topics suffix    |


### PR DESCRIPTION
Noticed a typo on the README.  This Fixes it.

`MQQT` to `MQTT`
`passwor` to `password`